### PR TITLE
Service and Characteristic Instance IDs

### DIFF
--- a/db/migrate/20180304115508_create_pairings.rb
+++ b/db/migrate/20180304115508_create_pairings.rb
@@ -1,10 +1,9 @@
 class CreatePairings < ActiveRecord::Migration[5.1]
   def change
     create_table :pairings do |t|
+      t.boolean :admin, default: false, null: false
       t.string :identifier, null: false, index: true
       t.string :public_key, null: false
-      t.boolean :admin, default: false, null: false
-      t.timestamps null: false
     end
   end
 end

--- a/db/migrate/20180304165428_create_characteristics.rb
+++ b/db/migrate/20180304165428_create_characteristics.rb
@@ -1,9 +1,11 @@
 class CreateCharacteristics < ActiveRecord::Migration[5.1]
   def change
     create_table :characteristics do |t|
+      t.integer :instance_id, null: false
+      t.references :accessory, null: false
+      t.references :service, null: false
       t.string :type, null: false
       t.string :value
-      t.references :service, null: false
     end
   end
 end

--- a/db/migrate/20180304181545_create_services.rb
+++ b/db/migrate/20180304181545_create_services.rb
@@ -1,10 +1,11 @@
 class CreateServices < ActiveRecord::Migration[5.1]
   def change
     create_table :services do |t|
-      t.string :type, null: false
       t.boolean :hidden, null: false, default: false
       t.boolean :primary, null: false, default: false
-      t.integer :accessory_id, null: false, default: 1
+      t.integer :instance_id, null: false
+      t.references :accessory, null: false
+      t.string :type, null: false
     end
   end
 end

--- a/db/migrate/20180305202245_create_instances.rb
+++ b/db/migrate/20180305202245_create_instances.rb
@@ -1,8 +1,0 @@
-class CreateInstances < ActiveRecord::Migration[5.1]
-  def change
-    create_table :instances do |t|
-      t.references :attributable, polymorphic: true
-    end
-  end
-end
-

--- a/db/migrate/20180306223336_create_accessories.rb
+++ b/db/migrate/20180306223336_create_accessories.rb
@@ -1,0 +1,6 @@
+class CreateAccessories < ActiveRecord::Migration[5.1]
+  def change
+    create_table :accessories do |t|
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,35 +10,35 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180305202245) do
+ActiveRecord::Schema.define(version: 20180306223336) do
+
+  create_table "accessories", force: :cascade do |t|
+  end
 
   create_table "characteristics", force: :cascade do |t|
+    t.integer "instance_id", null: false
+    t.integer "accessory_id", null: false
+    t.integer "service_id", null: false
     t.string "type", null: false
     t.string "value"
-    t.integer "service_id", null: false
+    t.index ["accessory_id"], name: "index_characteristics_on_accessory_id"
     t.index ["service_id"], name: "index_characteristics_on_service_id"
   end
 
-  create_table "instances", force: :cascade do |t|
-    t.string "attributable_type"
-    t.integer "attributable_id"
-    t.index ["attributable_type", "attributable_id"], name: "index_instances_on_attributable_type_and_attributable_id"
-  end
-
   create_table "pairings", force: :cascade do |t|
+    t.boolean "admin", default: false, null: false
     t.string "identifier", null: false
     t.string "public_key", null: false
-    t.boolean "admin", default: false, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.index ["identifier"], name: "index_pairings_on_identifier"
   end
 
   create_table "services", force: :cascade do |t|
-    t.string "type", null: false
     t.boolean "hidden", default: false, null: false
     t.boolean "primary", default: false, null: false
-    t.integer "accessory_id", default: 1, null: false
+    t.integer "instance_id", null: false
+    t.integer "accessory_id", null: false
+    t.string "type", null: false
+    t.index ["accessory_id"], name: "index_services_on_accessory_id"
   end
 
 end

--- a/lib/rubyhome.rb
+++ b/lib/rubyhome.rb
@@ -1,6 +1,4 @@
-require_relative 'rubyhome/version'
-require_relative 'rubyhome/broadcast'
-Dir[File.dirname(__FILE__) + '/rubyhome/hap/builders/*.rb'].each { |file| require file }
+Dir[File.dirname(__FILE__) + '/rubyhome/**/*.rb'].each { |file| require file }
 
 module Rubyhome
 end

--- a/lib/rubyhome.rb
+++ b/lib/rubyhome.rb
@@ -1,4 +1,6 @@
-Dir[File.dirname(__FILE__) + '/rubyhome/**/*.rb'].each { |file| require file }
+require_relative 'rubyhome/version'
+require_relative 'rubyhome/broadcast'
+Dir[File.dirname(__FILE__) + '/rubyhome/hap/builders/*.rb'].each { |file| require file }
 
 module Rubyhome
 end

--- a/lib/rubyhome/hap/builders/accessory_information_builder.rb
+++ b/lib/rubyhome/hap/builders/accessory_information_builder.rb
@@ -4,7 +4,9 @@ require_relative '../models/service'
 module Rubyhome
   class AccessoryInformationBuilder
     def initialize(**options)
-      @service = Rubyhome::Service::AccessoryInformation.new(options)
+
+      @accessory = options[:accessory] ||= Accessory.create!
+      @service = Rubyhome::Service::AccessoryInformation.new(options.merge(accessory: @accessory))
     end
 
     attr_reader :service

--- a/lib/rubyhome/hap/builders/accessory_information_builder.rb
+++ b/lib/rubyhome/hap/builders/accessory_information_builder.rb
@@ -4,7 +4,6 @@ require_relative '../models/service'
 module Rubyhome
   class AccessoryInformationBuilder
     def initialize(**options)
-
       @accessory = options[:accessory] ||= Accessory.create!
       @service = Rubyhome::Service::AccessoryInformation.new(options.merge(accessory: @accessory))
     end

--- a/lib/rubyhome/hap/builders/fan_builder.rb
+++ b/lib/rubyhome/hap/builders/fan_builder.rb
@@ -5,7 +5,8 @@ require_relative 'accessory_information_builder'
 module Rubyhome
   class FanBuilder
     def initialize
-      @service = Rubyhome::Service::Fan.new(accessory_id: 2)
+      @accessory = Accessory.create!
+      @service = Rubyhome::Service::Fan.new(accessory: @accessory)
     end
 
     attr_reader :service
@@ -18,7 +19,7 @@ module Rubyhome
     end
 
     def information
-      AccessoryInformationBuilder.new(accessory_id: 2)
+      AccessoryInformationBuilder.new(accessory: @accessory)
     end
 
     def save

--- a/lib/rubyhome/hap/models/accessory.rb
+++ b/lib/rubyhome/hap/models/accessory.rb
@@ -2,7 +2,6 @@ require_relative 'application_record'
 
 module Rubyhome
   class Accessory < ApplicationRecord
-
     has_many :services
     has_many :characteristics, through: :services
 

--- a/lib/rubyhome/hap/models/accessory.rb
+++ b/lib/rubyhome/hap/models/accessory.rb
@@ -1,17 +1,21 @@
+require_relative 'application_record'
+
 module Rubyhome
-  class Accessory
-    def self.all(grouped_services = Service.grouped_by_accessory)
-      grouped_services.inject(Array.new) do |array, (accessory_id, services)|
-        array << new(id: accessory_id, services: services)
-        array
-      end
+  class Accessory < ApplicationRecord
+
+    has_many :services
+    has_many :characteristics, through: :services
+
+    def next_available_instance_id
+      (largest_instance_id || 0) + 1
     end
 
-    def initialize(id:, services: [])
-      @id = id
-      @services = services
+    def instance_ids
+      services.pluck(:instance_id) + characteristics.pluck(:instance_id)
     end
 
-    attr_reader :id, :services
+    def largest_instance_id
+      instance_ids.max
+    end
   end
 end

--- a/lib/rubyhome/hap/models/characteristic.rb
+++ b/lib/rubyhome/hap/models/characteristic.rb
@@ -1,31 +1,23 @@
 require_relative 'application_record'
-require_relative 'instance'
 
 module Rubyhome
   class Characteristic < ApplicationRecord
     validates :type, presence: true
 
+    belongs_to :accessory, required: true
     belongs_to :service, required: true
-    has_one :instance, as: :attributable, required: true
 
-    def instance
-      super || build_instance
-    end
-
-    def iid
-      instance.id
-    end
-
-    def aid
-      service.accessory_id
-    end
-
-    before_create :build_associations
+    before_save :set_instance_id
+    before_validation :inherit_accessory
 
     private
 
-      def build_associations
-        instance
+      def set_instance_id
+        self.instance_id ||= accessory.next_available_instance_id
+      end
+
+      def inherit_accessory
+        self.accessory ||= service.accessory
       end
   end
 end

--- a/lib/rubyhome/hap/models/characteristic.rb
+++ b/lib/rubyhome/hap/models/characteristic.rb
@@ -16,6 +16,10 @@ module Rubyhome
       instance.id
     end
 
+    def aid
+      service.accessory_id
+    end
+
     before_create :build_associations
 
     private

--- a/lib/rubyhome/hap/models/instance.rb
+++ b/lib/rubyhome/hap/models/instance.rb
@@ -1,7 +1,0 @@
-require_relative 'application_record'
-
-module Rubyhome
-  class Instance < ApplicationRecord
-    belongs_to :attributable, polymorphic: true
-  end
-end

--- a/lib/rubyhome/hap/models/service.rb
+++ b/lib/rubyhome/hap/models/service.rb
@@ -1,31 +1,18 @@
 require_relative 'application_record'
-require_relative 'instance'
 
 module Rubyhome
   class Service < ApplicationRecord
-    def self.grouped_by_accessory
-      all.group_by(&:accessory_id)
-    end
-
     validates :type, presence: true
 
+    belongs_to :accessory, required: true
     has_many :characteristics
-    has_one :instance, as: :attributable, required: true
 
-    def instance
-      super || build_instance
-    end
-
-    def iid
-      instance.id
-    end
-
-    before_create :build_associations
+    before_save :set_instance_id
 
     private
 
-      def build_associations
-        instance
+      def set_instance_id
+        self.instance_id ||= accessory.next_available_instance_id
       end
   end
 end

--- a/lib/rubyhome/http/controllers/characteristics_controller.rb
+++ b/lib/rubyhome/http/controllers/characteristics_controller.rb
@@ -7,14 +7,14 @@ module Rubyhome
         content_type 'application/hap+json'
 
         if cache[:controller_to_accessory_key] && cache[:accessory_to_controller_key]
-          aid, iid = params[:id].split('.')
+          accessory_id, instance_id = params[:id].split('.')
 
-          characteristic = Instance.find(iid).attributable
+          characteristic = Characteristic.find_by(accessory_id: accessory_id, instance_id: instance_id)
           JSON.generate({
             'characteristics' => [
               {
-                'aid' => aid.to_i,
-                'iid' => iid.to_i,
+                'aid' => accessory_id.to_i,
+                'iid' => instance_id.to_i,
                 'value' => characteristic.value
               }
             ]

--- a/lib/rubyhome/http/public/example_accessory.json
+++ b/lib/rubyhome/http/public/example_accessory.json
@@ -76,11 +76,11 @@
       "aid": 2,
       "services": [
         {
-          "iid": 8,
+          "iid": 1,
           "type": "0000003E-0000-1000-8000-0026BB765291",
           "characteristics": [
             {
-              "iid": 9,
+              "iid": 2,
               "type": "00000014-0000-1000-8000-0026BB765291",
               "perms": [
                 "pw"
@@ -89,7 +89,7 @@
               "description": "Identify"
             },
             {
-              "iid": 10,
+              "iid": 3,
               "type": "00000020-0000-1000-8000-0026BB765291",
               "perms": [
                 "pr"
@@ -99,7 +99,7 @@
               "description": "Manufacturer"
             },
             {
-              "iid": 11,
+              "iid": 4,
               "type": "00000021-0000-1000-8000-0026BB765291",
               "perms": [
                 "pr"
@@ -109,7 +109,7 @@
               "description": "Model"
             },
             {
-              "iid": 12,
+              "iid": 5,
               "type": "00000023-0000-1000-8000-0026BB765291",
               "perms": [
                 "pr"
@@ -119,7 +119,7 @@
               "description": "Name"
             },
             {
-              "iid": 13,
+              "iid": 6,
               "type": "00000030-0000-1000-8000-0026BB765291",
               "perms": [
                 "pr"
@@ -129,7 +129,7 @@
               "description": "Serial Number"
             },
             {
-              "iid": 14,
+              "iid": 7,
               "type": "00000052-0000-1000-8000-0026BB765291",
               "perms": [
                 "pr"
@@ -143,11 +143,11 @@
           "hidden": false
         },
         {
-          "iid": 15,
+          "iid": 8,
           "type": "00000040-0000-1000-8000-0026BB765291",
           "characteristics": [
             {
-              "iid": 16,
+              "iid": 9,
               "type": "00000023-0000-1000-8000-0026BB765291",
               "perms": [
                 "pr"
@@ -157,7 +157,7 @@
               "description": "Name"
             },
             {
-              "iid": 17,
+              "iid": 10,
               "type": "00000025-0000-1000-8000-0026BB765291",
               "perms": [
                 "pr",

--- a/lib/rubyhome/http/serializers/characteristic_serializer.rb
+++ b/lib/rubyhome/http/serializers/characteristic_serializer.rb
@@ -8,7 +8,7 @@ module Rubyhome
       def record_hash(characteristic)
         record_hash = {}
 
-        record_hash['iid'] = characteristic.iid
+        record_hash['iid'] = characteristic.instance_id
         record_hash['type'] = characteristic.uuid
         record_hash['perms'] = characteristic.permissions
         record_hash['format'] = characteristic.format

--- a/lib/rubyhome/http/serializers/service_serializer.rb
+++ b/lib/rubyhome/http/serializers/service_serializer.rb
@@ -7,8 +7,8 @@ module Rubyhome
       include ObjectSerializer
 
       def record_hash(service)
-        base_hash = {
-          'iid' => service.iid,
+        {
+          'iid' => service.instance_id,
           'type' => service.uuid,
           'characteristics' => CharacteristicSerializer.new(service.characteristics).serializable_hash,
           'primary' => service.primary,

--- a/spec/http/requests/characteristics_spec.rb
+++ b/spec/http/requests/characteristics_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe '/characteristics' do
         Rubyhome::FanBuilder.new.save
         characteristic = Rubyhome::Characteristic::On.first
 
-        iid = characteristic.iid
-        aid = characteristic.aid
+        iid = characteristic.instance_id
+        aid = characteristic.accessory_id
 
         get "/characteristics?id=#{aid}.#{iid}", {'CONTENT_TYPE' => 'application/hap+json'}
 
@@ -42,8 +42,8 @@ RSpec.describe '/characteristics' do
         Rubyhome::FanBuilder.new.save
         characteristic = Rubyhome::Characteristic::On.first
 
-        iid = characteristic.iid
-        aid = characteristic.aid
+        iid = characteristic.instance_id
+        aid = characteristic.accessory_id
 
         get "/characteristics?id=#{aid}.#{iid}", {'CONTENT_TYPE' => 'application/hap+json'}
 

--- a/spec/http/requests/characteristics_spec.rb
+++ b/spec/http/requests/characteristics_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe '/characteristics' do
         iid = characteristic.instance_id
         aid = characteristic.accessory_id
 
-        get "/characteristics?id=#{aid}.#{iid}", {'CONTENT_TYPE' => 'application/hap+json'}
+        get '/characteristics', { id: [aid, iid].join('.') }, headers: { 'CONTENT_TYPE' => 'application/hap+json' }
 
         expect(last_response.status).to eql(200)
       end
@@ -45,9 +45,9 @@ RSpec.describe '/characteristics' do
         iid = characteristic.instance_id
         aid = characteristic.accessory_id
 
-        get "/characteristics?id=#{aid}.#{iid}", {'CONTENT_TYPE' => 'application/hap+json'}
+        get '/characteristics', { id: [aid, iid].join('.') }, headers: { 'CONTENT_TYPE' => 'application/hap+json' }
 
-        expected_data = {"characteristics" => [{"aid" => aid,"iid" => iid,"value" => false}]}
+        expected_data = { 'characteristics' => [{ 'aid' => aid, 'iid' => iid, 'value' => false }] }
         expect(last_response.body).to eql(JSON.generate(expected_data))
       end
     end
@@ -74,7 +74,7 @@ RSpec.describe '/characteristics' do
 
     context 'sufficient privileges and no error occurs' do
       let(:valid_parameters) do
-        JSON.generate({"characteristics" => [{"aid" => 2, "iid" => 10, "ev" => true}]})
+        JSON.generate({ 'characteristics' => [{ 'aid' => 2, 'iid' => 10, 'ev' => true }] })
       end
 
       before do

--- a/spec/http/requests/characteristics_spec.rb
+++ b/spec/http/requests/characteristics_spec.rb
@@ -19,6 +19,38 @@ RSpec.describe '/characteristics' do
         expect(last_response.body).to eql('{"status":-70401}')
       end
     end
+
+    context 'sufficient privileges and no error occurs' do
+      before do
+        set_cache(:controller_to_accessory_key, ['a' * 64].pack('H*'))
+        set_cache(:accessory_to_controller_key, ['b' * 64].pack('H*'))
+      end
+
+      it 'responds with a 204 No Content HTTP Status Code' do
+        Rubyhome::FanBuilder.new.save
+        characteristic = Rubyhome::Characteristic::On.first
+
+        iid = characteristic.iid
+        aid = characteristic.aid
+
+        get "/characteristics?id=#{aid}.#{iid}", {'CONTENT_TYPE' => 'application/hap+json'}
+
+        expect(last_response.status).to eql(200)
+      end
+
+      it 'responds with characteristics' do
+        Rubyhome::FanBuilder.new.save
+        characteristic = Rubyhome::Characteristic::On.first
+
+        iid = characteristic.iid
+        aid = characteristic.aid
+
+        get "/characteristics?id=#{aid}.#{iid}", {'CONTENT_TYPE' => 'application/hap+json'}
+
+        expected_data = {"characteristics" => [{"aid" => aid,"iid" => iid,"value" => false}]}
+        expect(last_response.body).to eql(JSON.generate(expected_data))
+      end
+    end
   end
 
   context 'PUT' do

--- a/spec/lib/hap/models/characteristics/firmware_revision_spec.rb
+++ b/spec/lib/hap/models/characteristics/firmware_revision_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
-require_relative '../../../../../lib/rubyhome/hap/models/characteristics/firmware_revision'
 
 RSpec.describe Rubyhome::Characteristic::FirmwareRevision, type: :model do
-  let(:service) { Rubyhome::Service::AccessoryInformation.create }
+  let(:accessory) { Rubyhome::Accessory.create }
+  let(:service) { Rubyhome::Service::AccessoryInformation.create!(accessory: accessory) }
   subject { described_class.new(value: '100.1.1', service: service) }
 
   describe 'Validations' do

--- a/spec/lib/hap/models/characteristics/identify_spec.rb
+++ b/spec/lib/hap/models/characteristics/identify_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
-require_relative '../../../../../lib/rubyhome/hap/models/characteristics/identify'
 
 RSpec.describe Rubyhome::Characteristic::Identify, type: :model do
-  let(:service) { Rubyhome::Service::AccessoryInformation.create }
-  subject { described_class.new(service: service) }
+  let(:accessory) { Rubyhome::Accessory.create }
+  let(:service) { Rubyhome::Service::AccessoryInformation.create(accessory: accessory) }
+  subject { described_class.new(value: '100.1.1', service: service) }
 
   describe 'Validations' do
     it 'is valid with valid attributes' do

--- a/spec/lib/hap/models/characteristics/manufacturer_spec.rb
+++ b/spec/lib/hap/models/characteristics/manufacturer_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
-require_relative '../../../../../lib/rubyhome/hap/models/characteristics/manufacturer'
 
 RSpec.describe Rubyhome::Characteristic::Manufacturer, type: :model do
-  let(:service) { Rubyhome::Service::AccessoryInformation.create }
+  let(:accessory) { Rubyhome::Accessory.create }
+  let(:service) { Rubyhome::Service::AccessoryInformation.create(accessory: accessory) }
   subject { described_class.new(value: 'Acme', service: service) }
 
   describe 'Validations' do

--- a/spec/lib/hap/models/characteristics/model_spec.rb
+++ b/spec/lib/hap/models/characteristics/model_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
-require_relative '../../../../../lib/rubyhome/hap/models/characteristics/model'
 
 RSpec.describe Rubyhome::Characteristic::Model, type: :model do
-  let(:service) { Rubyhome::Service::AccessoryInformation.create }
+  let(:accessory) { Rubyhome::Accessory.create }
+  let(:service) { Rubyhome::Service::AccessoryInformation.create(accessory: accessory) }
   subject { described_class.new(value: 'A1234', service: service) }
 
   describe 'Validations' do

--- a/spec/lib/hap/models/characteristics/name_spec.rb
+++ b/spec/lib/hap/models/characteristics/name_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
-require_relative '../../../../../lib/rubyhome/hap/models/characteristics/name'
 
 RSpec.describe Rubyhome::Characteristic::Name, type: :model do
-  let(:service) { Rubyhome::Service::AccessoryInformation.create }
+  let(:accessory) { Rubyhome::Accessory.create }
+  let(:service) { Rubyhome::Service::AccessoryInformation.create(accessory: accessory) }
   subject { described_class.new(value: 'Rubyhome', service: service) }
 
   describe 'Validations' do

--- a/spec/lib/hap/models/characteristics/serial_number_spec.rb
+++ b/spec/lib/hap/models/characteristics/serial_number_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
-require_relative '../../../../../lib/rubyhome/hap/models/characteristics/serial_number'
 
 RSpec.describe Rubyhome::Characteristic::SerialNumber, type: :model do
-  let(:service) { Rubyhome::Service::AccessoryInformation.create }
+  let(:accessory) { Rubyhome::Accessory.create }
+  let(:service) { Rubyhome::Service::AccessoryInformation.create(accessory: accessory) }
   subject { described_class.new(value: '1A2B3C4D5E6F', service: service) }
 
   describe 'Validations' do

--- a/spec/lib/hap/models/services/accessory_information_spec.rb
+++ b/spec/lib/hap/models/services/accessory_information_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 require_relative '../../../../../lib/rubyhome/hap/models/services/accessory_information'
 
 RSpec.describe Rubyhome::Service::AccessoryInformation, type: :model do
-  subject { described_class.new }
+  let(:accessory) { Rubyhome::Accessory.create }
+  subject { described_class.new(accessory: accessory) }
 
   describe 'Validations' do
     it 'is valid with valid attributes' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'bundler/setup'
 require 'rack/test'
 require 'rspec'
+require_relative '../lib/rubyhome'
 
 ENV['RACK_ENV'] = 'test'
 

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,12 +1,9 @@
 require 'database_cleaner'
 
 RSpec.configure do |config|
-  config.before(:suite) do
-    DatabaseCleaner.strategy = :transaction
-    DatabaseCleaner.clean_with(:truncation)
-  end
-
   config.around(:each) do |example|
+    DatabaseCleaner[:active_record].strategy = :truncation
+
     DatabaseCleaner.cleaning do
       example.run
     end


### PR DESCRIPTION
Service and Characteristic instance IDs, "iid", are assigned from the same number pool that is unique within each Accessory object. For example, if the first Service object has an instance ID of "1" then no other Service or Characteristic objects can have an instance ID of "1" within the parent Accessory object. The Accessory Information service must have a service instance ID of 1.

After a firmware update services and characteristics types that remain unchanged must retain their previous instance ids, newly added services and characteristics must not reuse instance ids from services and characteristics that were removed in the firmware update.